### PR TITLE
Exposed Validate on CLI and imported iconfactory

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,7 +12,8 @@ const args = require('minimist')(process.argv.slice(2), {
     m: 'minify',
     d: 'mode',
     o: 'options',
-    v: 'version'
+    v: 'version',
+    l: 'validate'
   },
   default: {
     dir: process.cwd()
@@ -39,12 +40,13 @@ Flags:
                     [spa|pwa|cordova|electron|kitchensink|custom]
   -s, --source      Your source image as a large square png
   -t, --target      The destination directory for the files created
-  -o, --options     path to file that overrides defaults (if custom)
+  -o, --options     Path to file that overrides defaults (if custom)
   -m, --minify      Minify strategy to use. 
                     [pngcrush|pngquant|optipng|pngout|zopfli]
   -d, --mode        Minify mode if minify preset [folder|singlefile]
-  -v, --version     display version information
-  -h, --help        display this information
+  -v, --version     Display version information
+  -h, --help        Display this information
+  -l, --validate    Check the image is valid for processing 
   
 Usage:
     
@@ -127,6 +129,9 @@ switch (args.preset) {
     break
   case 'custom':
     iconfactory.custom(args.source, args.target, args.options)
+    break
+  case 'validate':
+    iconfactory.validate(args.source, args.target)
     break
   default:
     console.log('You must supply a preset')

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,12 +131,15 @@ const hexToRgb = function(hex) {
     : null
 }
 
-const verify = async function(src, target) {
+const validate = async function(src, target) {
   await checkSrc(src)
   await ensureDir(target)
 }
 
 let iconfactory = exports.iconfactory = {
+  validate: async function (src, target) {
+    return await validate(src, target)
+  },
   version: function() {
     return require('../package.json').version
   },
@@ -145,7 +148,7 @@ let iconfactory = exports.iconfactory = {
   },
   cordova: async function(src, target, strategy, options) {
     options = options || settings.options.cordova
-    await verify(src, target)
+    await validate(src, target)
     await this.splash(src, target, options)
     await this.build(src, target, options)
     if (strategy) {
@@ -156,7 +159,7 @@ let iconfactory = exports.iconfactory = {
   },
   electron: async function(src, target, strategy, options) {
     options = options || settings.options.electron
-    await verify(src, target)
+    await validate(src, target)
     await this.build(src, target, options)
     if (strategy) {
       await this.minify(target, options, strategy, 'batch')
@@ -167,7 +170,7 @@ let iconfactory = exports.iconfactory = {
   },
   pwa: async function(src, target, strategy, options) {
     options = options || settings.options.pwa
-    await verify(src, target)
+    await validate(src, target)
     await this.build(src, target, options)
     if (strategy) {
       await this.minify(target, options, strategy, 'batch')
@@ -178,7 +181,7 @@ let iconfactory = exports.iconfactory = {
   },
   spa: async function(src, target, strategy, options) {
     options = options || settings.options.spa
-    await verify(src, target)
+    await validate(src, target)
     await this.build(src, target, options)
     if (strategy) {
       await this.minify(target, options, strategy, 'batch')
@@ -203,7 +206,7 @@ let iconfactory = exports.iconfactory = {
    * @param {string} options - js object that defines path and sizes
    */
   build: async function(src, target, options) {
-    await verify(src, target) // creates the image object
+    await validate(src, target) // creates the image object
     const buildify2 = async function (pvar) {
       try {
         let pngImage = image.resize(pvar[1], pvar[1]).png()
@@ -251,7 +254,7 @@ let iconfactory = exports.iconfactory = {
     let rgb = hexToRgb(settings.options.background_color)
     // console.log('RGB', rgb.r, rgb.g, rgb.b)
 
-    await verify(src, target)
+    await validate(src, target)
     if (!image) {
       process.exit(1)
     }
@@ -357,7 +360,7 @@ let iconfactory = exports.iconfactory = {
         process.exit(1)
       }
 
-      await verify(src, target)
+      await validate(src, target)
 
       let sharpSrc = sharp(src)
       let buf = await sharpSrc.toBuffer()
@@ -382,7 +385,7 @@ let iconfactory = exports.iconfactory = {
    */
   favicon: async function(src, target) {
     try {
-      await verify(src, target)
+      await validate(src, target)
       if (!image) {
         process.exit(1)
       }
@@ -420,7 +423,7 @@ let iconfactory = exports.iconfactory = {
         optTolerance: settings.options.svg.optTolerance
       }
 
-      await verify(src, target)
+      await validate(src, target)
       if (!image) {
         process.exit(1)
       }
@@ -446,7 +449,7 @@ let iconfactory = exports.iconfactory = {
         background: settings.options.background_color
       }
       await ensureDir(`${target}`)
-      await verify(src, target)
+      await validate(src, target)
       if (!image) {
         process.exit(1)
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,8 @@ const validate = async function(src, target) {
 
 let iconfactory = exports.iconfactory = {
   validate: async function (src, target) {
-    return await validate(src, target)
+    await validate(src, target)
+    return image !== null
   },
   version: function() {
     return require('../package.json').version
@@ -148,7 +149,7 @@ let iconfactory = exports.iconfactory = {
   },
   cordova: async function(src, target, strategy, options) {
     options = options || settings.options.cordova
-    await validate(src, target)
+    await this.validate(src, target)
     await this.splash(src, target, options)
     await this.build(src, target, options)
     if (strategy) {
@@ -159,7 +160,7 @@ let iconfactory = exports.iconfactory = {
   },
   electron: async function(src, target, strategy, options) {
     options = options || settings.options.electron
-    await validate(src, target)
+    await this.validate(src, target)
     await this.build(src, target, options)
     if (strategy) {
       await this.minify(target, options, strategy, 'batch')
@@ -170,7 +171,7 @@ let iconfactory = exports.iconfactory = {
   },
   pwa: async function(src, target, strategy, options) {
     options = options || settings.options.pwa
-    await validate(src, target)
+    await this.validate(src, target)
     await this.build(src, target, options)
     if (strategy) {
       await this.minify(target, options, strategy, 'batch')
@@ -181,7 +182,7 @@ let iconfactory = exports.iconfactory = {
   },
   spa: async function(src, target, strategy, options) {
     options = options || settings.options.spa
-    await validate(src, target)
+    await this.validate(src, target)
     await this.build(src, target, options)
     if (strategy) {
       await this.minify(target, options, strategy, 'batch')
@@ -206,7 +207,7 @@ let iconfactory = exports.iconfactory = {
    * @param {string} options - js object that defines path and sizes
    */
   build: async function(src, target, options) {
-    await validate(src, target) // creates the image object
+    await this.validate(src, target) // creates the image object
     const buildify2 = async function (pvar) {
       try {
         let pngImage = image.resize(pvar[1], pvar[1]).png()
@@ -254,7 +255,7 @@ let iconfactory = exports.iconfactory = {
     let rgb = hexToRgb(settings.options.background_color)
     // console.log('RGB', rgb.r, rgb.g, rgb.b)
 
-    await validate(src, target)
+    await this.validate(src, target)
     if (!image) {
       process.exit(1)
     }
@@ -360,7 +361,7 @@ let iconfactory = exports.iconfactory = {
         process.exit(1)
       }
 
-      await validate(src, target)
+      await this.validate(src, target)
 
       let sharpSrc = sharp(src)
       let buf = await sharpSrc.toBuffer()
@@ -385,7 +386,7 @@ let iconfactory = exports.iconfactory = {
    */
   favicon: async function(src, target) {
     try {
-      await validate(src, target)
+      await this.validate(src, target)
       if (!image) {
         process.exit(1)
       }
@@ -423,7 +424,7 @@ let iconfactory = exports.iconfactory = {
         optTolerance: settings.options.svg.optTolerance
       }
 
-      await validate(src, target)
+      await this.validate(src, target)
       if (!image) {
         process.exit(1)
       }
@@ -449,7 +450,7 @@ let iconfactory = exports.iconfactory = {
         background: settings.options.background_color
       }
       await ensureDir(`${target}`)
-      await validate(src, target)
+      await this.validate(src, target)
       if (!image) {
         process.exit(1)
       }


### PR DESCRIPTION
Renamed verify to validate so it's more self explanatory.
Changed some casing on the CLI help so its consistent.
Exposed Validate on the CLI and imported iconfactory instance.

fix #41 