### PR TITLE
Revise validate return and add comment about process.exit call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,7 @@ const checkSrc = async function (src) {
         image = false
         console.error('* [ERROR] Source image for icon-factory is not a png')
         // exit because this is BAD!
+        // Developers should catch () { } this as this is the last chance to stop bad things happening.
         process.exit(1)
       }
     }
@@ -139,7 +140,7 @@ const validate = async function(src, target) {
 let iconfactory = exports.iconfactory = {
   validate: async function (src, target) {
     await validate(src, target)
-    return image !== null
+    return typeof image === 'object'
   },
   version: function() {
     return require('../package.json').version


### PR DESCRIPTION
Revise return for validate as image can be returned false as well so wouldn't always fail when it should.

Added comment about keeping process.exit in place and how to handle it.